### PR TITLE
Fix no accessible initializers

### DIFF
--- a/SwiftWebViewProgress/SwiftWebViewProgress/SwiftWebViewProgress.swift
+++ b/SwiftWebViewProgress/SwiftWebViewProgress/SwiftWebViewProgress.swift
@@ -13,36 +13,36 @@ public protocol WebViewProgressDelegate {
 }
 
 public class WebViewProgress: NSObject {
-    
+
     public var progressDelegate: WebViewProgressDelegate?
     public var webViewProxyDelegate: UIWebViewDelegate?
     public var progress: Float = 0.0
-    
+
     private var loadingCount: Int!
     private var maxLoadCount: Int!
     private var currentUrl: NSURL?
     private var interactive: Bool!
-    
+
     private let InitialProgressValue: Float = 0.1
     private let InteractiveProgressValue: Float = 0.5
     private let FinalProgressValue: Float = 0.9
     private let completePRCURLPath = "/webviewprogressproxy/complete"
-    
+
     // MARK: Initializer
-    override init() {
+    override public init() {
         super.init()
         maxLoadCount = 0
         loadingCount = 0
         interactive = false
     }
-    
+
     // MARK: Private Method
     private func startProgress() {
         if progress < InitialProgressValue {
             setProgress(InitialProgressValue)
         }
     }
-    
+
     private func incrementProgress() {
         var progress = self.progress
         let maxProgress = interactive == true ? FinalProgressValue : InteractiveProgressValue
@@ -52,11 +52,11 @@ public class WebViewProgress: NSObject {
         progress = fmin(progress, maxProgress)
         setProgress(progress)
     }
-    
+
     private func completeProgress() {
         setProgress(1.0)
     }
-    
+
     private func setProgress(progress: Float) {
         guard progress > self.progress || progress == 0 else {
             return
@@ -64,7 +64,7 @@ public class WebViewProgress: NSObject {
         self.progress = progress
         progressDelegate?.webViewProgress(self, updateProgress: progress)
     }
-    
+
     // MARK: Public Method
     public func reset() {
         maxLoadCount = 0
@@ -72,7 +72,7 @@ public class WebViewProgress: NSObject {
         interactive = false
         setProgress(0.0)
     }
-    
+
 }
 
 extension WebViewProgress: UIWebViewDelegate {
@@ -84,18 +84,18 @@ extension WebViewProgress: UIWebViewDelegate {
             completeProgress()
             return false
         }
-        
+
         var ret = true
         if webViewProxyDelegate!.respondsToSelector("webView:shouldStartLoadWithRequest:navigationType:") {
             ret = webViewProxyDelegate!.webView!(webView, shouldStartLoadWithRequest: request, navigationType: navigationType)
         }
-        
+
         var isFragmentJump = false
         if let fragmentURL = url.fragment {
             let nonFragmentURL = url.absoluteString.stringByReplacingOccurrencesOfString("#"+fragmentURL, withString: "")
             isFragmentJump = nonFragmentURL == webView.request!.URL!.absoluteString
         }
-        
+
         let isTopLevelNavigation = request.mainDocumentURL! == request.URL
         let isHTTP = url.scheme == "http" || url.scheme == "https"
         if ret && !isFragmentJump && isHTTP && isTopLevelNavigation {
@@ -104,71 +104,71 @@ extension WebViewProgress: UIWebViewDelegate {
         }
         return ret
     }
-    
+
     public func webViewDidStartLoad(webView: UIWebView) {
         if webViewProxyDelegate!.respondsToSelector("webViewDidStartLoad:") {
             webViewProxyDelegate!.webViewDidStartLoad!(webView)
         }
-        
+
         loadingCount = loadingCount + 1
         maxLoadCount = Int(fmax(Double(maxLoadCount), Double(loadingCount)))
         startProgress()
     }
-    
+
     public func webViewDidFinishLoad(webView: UIWebView) {
         if webViewProxyDelegate!.respondsToSelector("webViewDidFinishLoad:") {
             webViewProxyDelegate!.webViewDidFinishLoad!(webView)
         }
-        
+
         loadingCount = loadingCount - 1
         incrementProgress()
-        
+
         let readyState = webView.stringByEvaluatingJavaScriptFromString("document.readyState")
-        
+
         let interactive = readyState == "interactive"
         if interactive {
             self.interactive = true
             let waitForCompleteJS = "window.addEventListener('load',function() { var iframe = document.createElement('iframe'); iframe.style.display = 'none'; iframe.src = '\(webView.request?.mainDocumentURL?.scheme)://\(webView.request?.mainDocumentURL?.host)\(completePRCURLPath)'; document.body.appendChild(iframe);  }, false);"
             webView.stringByEvaluatingJavaScriptFromString(waitForCompleteJS)
         }
-        
+
         let isNotRedirect: Bool
         if let currentUrl = currentUrl {
             isNotRedirect = currentUrl == webView.request?.mainDocumentURL
         } else {
             isNotRedirect = false
         }
-        
+
         let complete = readyState == "complete"
         if complete && isNotRedirect {
             completeProgress()
         }
     }
-    
+
     public func webView(webView: UIWebView, didFailLoadWithError error: NSError?) {
         if webViewProxyDelegate!.respondsToSelector("webView:didFailLoadWithError:") {
             webViewProxyDelegate!.webView!(webView, didFailLoadWithError: error)
         }
-        
+
         loadingCount = loadingCount - 1
         incrementProgress()
-        
+
         let readyState = webView.stringByEvaluatingJavaScriptFromString("document.readyState")
-        
+
         let interactive = readyState == "interactive"
         if interactive {
             self.interactive = true
             let waitForCompleteJS = "window.addEventListener('load',function() { var iframe = document.createElement('iframe'); iframe.style.display = 'none'; iframe.src = '\(webView.request?.mainDocumentURL?.scheme)://\(webView.request?.mainDocumentURL?.host)\(completePRCURLPath)'; document.body.appendChild(iframe);  }, false);"
             webView.stringByEvaluatingJavaScriptFromString(waitForCompleteJS)
         }
-        
+
         let isNotRedirect: Bool
         if let currentUrl = currentUrl {
             isNotRedirect = currentUrl == webView.request?.mainDocumentURL
         } else {
             isNotRedirect = false
         }
-        
+
         let complete = readyState == "complete"
         if complete && isNotRedirect {
             completeProgress()

--- a/SwiftWebViewProgress/SwiftWebViewProgress/SwiftWebViewProgressView.swift
+++ b/SwiftWebViewProgress/SwiftWebViewProgress/SwiftWebViewProgressView.swift
@@ -9,15 +9,15 @@
 import UIKit
 
 public class WebViewProgressView: UIView {
-    
+
     var progress: Float = 0.0
     var progressBarView: UIView!
     var barAnimationDuration: NSTimeInterval!
     var fadeAnimationDuration: NSTimeInterval!
     var fadeOutDelay: NSTimeInterval!
-    
+
     // MARK: Initializer
-    override init(frame: CGRect) {
+    override public init(frame: CGRect) {
         super.init(frame: frame)
         configureViews()
     }
@@ -25,12 +25,12 @@ public class WebViewProgressView: UIView {
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
-    
+
     override public func awakeFromNib() {
         super.awakeFromNib()
         configureViews()
     }
-    
+
     // MARK: Private Method
     private func configureViews() {
         self.userInteractionEnabled = false
@@ -43,12 +43,12 @@ public class WebViewProgressView: UIView {
         }
         progressBarView.backgroundColor = tintColor
         self.addSubview(progressBarView)
-        
+
         barAnimationDuration = 0.1
         fadeAnimationDuration = 0.27
         fadeOutDelay = 0.1
     }
-    
+
     // MARK: Public Method
     public func setProgress(progress: Float, animated: Bool = false) {
         let isGrowing = progress > 0.0
@@ -57,7 +57,7 @@ public class WebViewProgressView: UIView {
             frame.size.width = CGFloat(progress) * self.bounds.size.width
             self.progressBarView.frame = frame
         }, completion: nil)
-        
+
         if progress >= 1.0 {
             UIView.animateWithDuration(animated ? fadeAnimationDuration : 0.0, delay: fadeOutDelay, options: .CurveEaseInOut, animations: {
                 self.progressBarView.alpha = 0.0


### PR DESCRIPTION
The WebViewProgress using `import SwiftWebViewProgress` with CocoaPods throws this error when try `progressProxy = WebViewProgress()`

`'WebViewProgress' cannot be constructed because it has no accessible initialisers`

This error can be solved using:

```
override public init() {
    super.init()
    maxLoadCount = 0
    loadingCount = 0
    interactive = false
}
```

instead of:

```
override init() {
    super.init()
    maxLoadCount = 0
    loadingCount = 0
    interactive = false
}
```

Just indicate explicitly `public` after `override`

The same for `WebViewProgressView` initializer:

```
override public init(frame: CGRect) {
    super.init(frame: frame)
    configureViews()
}
```
